### PR TITLE
Fix build failure by escaping special characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function loader(source) {
   return `
     import { css } from 'lit-element';
-    export default css\`${ source }\`;
+    export default css\`${ source.replace(/(`|\\|\${)/g, '\\$1') }\`;
   `;
 }
 


### PR DESCRIPTION
Fixes #1

Escapes backtick, backslash and `${` with a backslash when injecting the source CSS into a template literal in the generated ES module.