### PR TITLE
feat!: upgrade to use Lit 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = function loader(source) {
   return `
-    import { css } from 'lit-element';
+    import { css } from 'lit';
     export default css\`${ source.replace(/(`|\\|\${)/g, '\\$1') }\`;
   `;
 }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/bennypowers/lit-css-loader/issues"
   },
-  "homepage": "https://github.com/bennypowers/lit-css-loader#readme"
+  "homepage": "https://github.com/bennypowers/lit-css-loader#readme",
+  "peerDependencies": {
+    "lit": "^2.0.0-rc.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/bennypowers/lit-css-loader#readme",
   "peerDependencies": {
-    "lit": "^2.0.0-rc.1"
+    "lit": "^2.0.0 || ^2.0.0-rc.1"
   }
 }


### PR DESCRIPTION
Fixes #3 

This is an alternative approach which makes the loader compatible with Lit 2, but not 1. So this is a breaking change.